### PR TITLE
Implement real MiniMax integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# snapcloud
+# SnapCloud
+
+SnapCloud converts a high level requirement into AWS deliverables. It now performs real requests to the **MiniMax** API to generate tasks, an architecture diagram, a CloudFormation template and a cost estimation.
+
+## Usage
+
+Set the environment variables before running the backend:
+
+```
+MINIMAX_API_KEY=your_key_here
+# MINIMAX_API_URL=https://api.minimax.io/v1/text/chatcompletion_v2 (optional)
+```
+
+Start the API server:
+
+```
+npm run dev
+```
+
+Send a POST request to `/generate` with a JSON body containing `requirement` to receive the deliverables.

--- a/src/agents/minimax.ts
+++ b/src/agents/minimax.ts
@@ -1,11 +1,11 @@
 /**
  * Minimal MiniMax wrapper for SnapCloud
  * --------------------------------------
- * Fournit deux helpers :
+ * Provides two helpers:
  *   - splitSnapTasks(requirement): Promise<string[]>
  *   - generateArchitecture(tasks): Promise<{ diagramMermaid: string, cfnTemplate: string }>
  *
- * Nécessite la variable d'environnement :
+ * Requires the environment variable:
  *   MINIMAX_API_KEY
  */
 import fetch from "node-fetch";
@@ -14,20 +14,20 @@ const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
 const MINIMAX_API_URL = process.env.MINIMAX_API_URL || "https://api.minimax.io/v1/text/chatcompletion_v2";
 
 if (!MINIMAX_API_KEY) {
-  throw new Error("MINIMAX_API_KEY manquant dans l'environnement");
+  throw new Error("MINIMAX_API_KEY missing from environment");
 }
 
-// Fonction utilitaire pour nettoyer les réponses MiniMax
+// Utility function to clean MiniMax responses
 function cleanMiniMaxResponse(response: string): string {
-  // Supprimer les blocs de code markdown ```json...```
+  // Remove ```json``` code fences
   let cleaned = response
     .replace(/```json\s*/gi, '')
     .replace(/```\s*/g, '')
-    .replace(/^[^\[\{]*/, '') // Supprimer tout avant le premier [ ou {
-    .replace(/[^\]\}]*$/, '') // Supprimer tout après le dernier ] ou }
+    .replace(/^[^\[\{]*/, '') // Drop everything before the first [ or {
+    .replace(/[^\]\}]*$/, '') // Drop everything after the last ] or }
     .trim();
-  
-  // Si la réponse est tronquée, essayer de la compléter
+
+  // If the reply looks truncated, try to close the array
   if (cleaned.endsWith(',') || (!cleaned.endsWith(']') && !cleaned.endsWith('}') && cleaned.includes('['))) {
     cleaned = cleaned.replace(/,$/, '') + ']';
   }
@@ -36,223 +36,74 @@ function cleanMiniMaxResponse(response: string): string {
 }
 
 export async function splitSnapTasks(requirement: string): Promise<string[]> {
-  // Version simplifiée pour les tests - TODO: améliorer le parsing MiniMax
-  const defaultTasks = [
-    "Initialiser le projet",
-    "Configurer la base de données",
-    "Créer les modèles de données",
-    "Développer l'interface utilisateur",
-    "Implémenter les API REST",
-    "Ajouter l'authentification",
-    "Configurer le déploiement",
-    "Effectuer les tests"
-  ];
-  
   console.log(`[DEBUG] Splitting requirement: ${requirement}`);
-  return defaultTasks;
+
+  const prompt =
+    `You are SnapCloud AI. Split the following user requirement into technical tasks ` +
+    `to design the AWS architecture. ` +
+    `Respond only with a JSON array of strings.\n\n` +
+    `Requirement:\n${requirement}`;
+
+  try {
+    const raw = await callMiniMax(prompt);
+    const cleaned = cleanMiniMaxResponse(raw);
+    const tasks = JSON.parse(cleaned);
+    if (Array.isArray(tasks)) {
+      return tasks.map((t) => String(t));
+    }
+    console.warn('[splitSnapTasks] MiniMax response was not an array:', tasks);
+  } catch (err) {
+    console.error('[splitSnapTasks] Falling back to single task list:', err);
+  }
+
+  return [requirement];
 }
 
-export async function generateArchitecture(tasks: string[]): Promise<{ 
-  diagramMermaid: string; 
-  cfnTemplate: string; 
+export async function generateArchitecture(tasks: string[]): Promise<{
+  diagramMermaid: string;
+  cfnTemplate: string;
   costEstimation: {
     json: any;
     table: string;
   }
 }> {
   console.log(`[DEBUG] Generating architecture for ${tasks.length} tasks`);
-  
-  // Version simplifiée pour les tests - TODO: implémenter MiniMax
-  const diagramMermaid = `graph TD
-    A["👤 Users"] --> B["⚖️ Application Load Balancer"]
-    B --> C["🖥️ EC2 Auto Scaling Group"]
-    C --> D["💾 RDS MySQL Database"]
-    C --> E["📁 S3 Bucket (Static Assets)"]
-    B --> F["🌐 CloudFront CDN"]
-    F --> E
-    C --> G["🔐 ElastiCache Redis"]
-    
-    style A fill:#e1f5fe
-    style B fill:#f3e5f5
-    style C fill:#e8f5e8
-    style D fill:#fff3e0
-    style E fill:#fce4ec
-    style F fill:#f1f8e9
-    style G fill:#fff8e1`;
-    
-  const cfnTemplate = `AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Architecture AWS générée par SnapCloud'
 
-Parameters:
-  EnvironmentName:
-    Description: Environment name prefix
-    Type: String
-    Default: snapcloud
+  const bulletTasks = tasks.map((t, i) => `${i + 1}. ${t}`).join('\n');
+  const prompt =
+    `You are SnapCloud AI. Based on the following tasks:\n${bulletTasks}` +
+    `
 
-Resources:
-  # VPC and Networking
-  VPC:
-    Type: AWS::EC2::VPC
-    Properties:
-      CidrBlock: 10.0.0.0/16
-      EnableDnsHostnames: true
-      EnableDnsSupport: true
-      Tags:
-        - Key: Name
-          Value: !Sub \${EnvironmentName}-VPC
+Provide exactly four markdown code blocks in this order:\n` +
+    `1. \`\`\`mermaid\n<diagram>\n\`\`\`\n` +
+    `2. \`\`\`yaml\n<CloudFormation>\n\`\`\`\n` +
+    `3. \`\`\`json\n<cost estimation json>\n\`\`\`\n` +
+    `4. \`\`\`markdown\n<cost table>\n\`\`\``;
 
-  # Application Load Balancer
-  ApplicationLoadBalancer:
-    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
-    Properties:
-      Name: !Sub \${EnvironmentName}-ALB
-      Type: application
-      Scheme: internet-facing
-      SecurityGroups:
-        - !Ref ALBSecurityGroup
-      Subnets:
-        - !Ref PublicSubnet1
-        - !Ref PublicSubnet2
+  const raw = await callMiniMax(prompt);
 
-  # Auto Scaling Group
-  AutoScalingGroup:
-    Type: AWS::AutoScaling::AutoScalingGroup
-    Properties:
-      AutoScalingGroupName: !Sub \${EnvironmentName}-ASG
-      VPCZoneIdentifier:
-        - !Ref PrivateSubnet1
-        - !Ref PrivateSubnet2
-      LaunchTemplate:
-        LaunchTemplateId: !Ref LaunchTemplate
-        Version: !GetAtt LaunchTemplate.LatestVersionNumber
-      MinSize: 2
-      MaxSize: 10
-      DesiredCapacity: 2
-      TargetGroupARNs:
-        - !Ref TargetGroup
+  const mermaidMatch = raw.match(/```mermaid[\s\S]*?```/i);
+  const yamlMatch = raw.match(/```yaml[\s\S]*?```/i);
+  const jsonMatch = raw.match(/```json[\s\S]*?```/i);
+  const tableMatch = raw.match(/```(?:markdown|md)[\s\S]*?```/i);
 
-  # RDS Database
-  Database:
-    Type: AWS::RDS::DBInstance
-    Properties:
-      DBInstanceIdentifier: !Sub \${EnvironmentName}-db
-      DBInstanceClass: db.t3.micro
-      Engine: mysql
-      EngineVersion: '8.0'
-      MasterUsername: admin
-      MasterUserPassword: !Ref DatabasePassword
-      AllocatedStorage: 20
-      StorageType: gp2
-      VPCSecurityGroups:
-        - !Ref DatabaseSecurityGroup
-      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+  const cleanBlock = (block?: string) =>
+    block ? block.replace(/```(mermaid|yaml|json|markdown|md)?/gi, '').trim() : '';
 
-  # S3 Bucket
-  S3Bucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !Sub \${EnvironmentName}-static-assets
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: false
-        BlockPublicPolicy: false
-        IgnorePublicAcls: false
-        RestrictPublicBuckets: false
+  let costJson: any = {};
+  try {
+    costJson = JSON.parse(cleanMiniMaxResponse(jsonMatch ? jsonMatch[0] : '{}'));
+  } catch (err) {
+    console.error('[generateArchitecture] Failed to parse cost JSON:', err);
+  }
 
-  # CloudFront Distribution
-  CloudFrontDistribution:
-    Type: AWS::CloudFront::Distribution
-    Properties:
-      DistributionConfig:
-        Origins:
-          - DomainName: !GetAtt S3Bucket.RegionalDomainName
-            Id: S3Origin
-            S3OriginConfig:
-              OriginAccessIdentity: ''
-        Enabled: true
-        DefaultCacheBehavior:
-          TargetOriginId: S3Origin
-          ViewerProtocolPolicy: redirect-to-https
-          AllowedMethods:
-            - GET
-            - HEAD
-          CachedMethods:
-            - GET
-            - HEAD
-          ForwardedValues:
-            QueryString: false
-            Cookies:
-              Forward: none
-
-Outputs:
-  LoadBalancerDNS:
-    Description: DNS name of the load balancer
-    Value: !GetAtt ApplicationLoadBalancer.DNSName
-    Export:
-      Name: !Sub \${EnvironmentName}-ALB-DNS
-
-  DatabaseEndpoint:
-    Description: RDS instance endpoint
-    Value: !GetAtt Database.Endpoint.Address
-    Export:
-      Name: !Sub \${EnvironmentName}-DB-Endpoint`;
-      
-  // Estimation de coût simplifiée
-  const costEstimation = {
-    json: {
-      "totalMonthlyCost": 156.50,
-      "currency": "USD",
-      "region": "us-east-1",
-      "breakdown": [
-        {
-          "service": "EC2 Instances",
-          "instanceType": "t3.micro",
-          "quantity": 2,
-          "hourlyCost": 0.0104,
-          "monthlyCost": 15.00
-        },
-        {
-          "service": "Application Load Balancer",
-          "quantity": 1,
-          "monthlyCost": 22.50
-        },
-        {
-          "service": "RDS MySQL",
-          "instanceType": "db.t3.micro",
-          "storage": "20GB",
-          "monthlyCost": 25.00
-        },
-        {
-          "service": "S3 Storage",
-          "storage": "100GB",
-          "monthlyCost": 2.30
-        },
-        {
-          "service": "CloudFront CDN",
-          "dataTransfer": "1TB",
-          "monthlyCost": 85.00
-        },
-        {
-          "service": "ElastiCache Redis",
-          "instanceType": "cache.t3.micro",
-          "monthlyCost": 6.70
-        }
-      ]
-    },
-    table: `| Service | Type | Quantité | Coût Mensuel |
-|---------|------|----------|---------------|
-| EC2 Instances | t3.micro | 2 | $15.00 |
-| Load Balancer | ALB | 1 | $22.50 |
-| RDS MySQL | db.t3.micro | 20GB | $25.00 |
-| S3 Storage | Standard | 100GB | $2.30 |
-| CloudFront | CDN | 1TB transfer | $85.00 |
-| ElastiCache | cache.t3.micro | 1 | $6.70 |
-| **TOTAL** | | | **$156.50/mois** |`
-  };
-      
   return {
-    diagramMermaid,
-    cfnTemplate,
-    costEstimation
+    diagramMermaid: cleanBlock(mermaidMatch?.[0]),
+    cfnTemplate: cleanBlock(yamlMatch?.[0]),
+    costEstimation: {
+      json: costJson,
+      table: cleanBlock(tableMatch?.[0]),
+    },
   };
 }
 
@@ -280,18 +131,18 @@ async function callMiniMax(prompt: string): Promise<any> {
     throw new Error(`MiniMax API error: ${res.status} ${await res.text()}`);
   }
   const data = await res.json();
-  // Le texte généré est dans data.choices[0].message.content
+  // The generated text is in data.choices[0].message.content
   return data.choices?.[0]?.message?.content || data.result || data;
 }
 
-// Si tu veux tester en CLI :
+// CLI self-test
 if (import.meta.url === `file://${process.argv[1]}` && process.argv.length > 2) {
   (async () => {
     const requirement = process.argv.slice(2).join(" ");
     const tasks = await splitSnapTasks(requirement);
-    console.log("Tâches :", tasks);
+    console.log("Tasks:", tasks);
     const archi = await generateArchitecture(tasks);
-    console.log("Diagramme :\n", archi.diagramMermaid);
-    console.log("CFN :\n", archi.cfnTemplate);
+    console.log("Diagram:\n", archi.diagramMermaid);
+    console.log("CFN:\n", archi.cfnTemplate);
   })();
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 // src/api/index.ts
-// API REST pour SnapCloud (appelle MiniMax directement)
+// REST API for SnapCloud (calls MiniMax directly)
 import dotenv from "dotenv";
 dotenv.config();
 
@@ -11,12 +11,12 @@ app.use(express.json());
 
 app.post("/generate", async (req, res) => {
   const { requirement } = req.body;
-  if (!requirement) return res.status(400).json({ error: "Champ 'requirement' manquant" });
+  if (!requirement) return res.status(400).json({ error: "Missing 'requirement' field" });
   try {
-    // Étape 1: Découper le besoin en tâches atomiques
+    // Step 1: split the requirement into atomic tasks
     const tasks = await splitSnapTasks(requirement);
-    
-    // Étape 2: Générer l'architecture AWS et le template CloudFormation
+
+    // Step 2: generate the AWS architecture and CloudFormation template
     const { diagramMermaid, cfnTemplate, costEstimation } = await generateArchitecture(tasks);
     
     res.json({


### PR DESCRIPTION
## Summary
- connect `splitSnapTasks` and `generateArchitecture` to MiniMax
- add parsing of MiniMax responses
- document API usage and required environment variables
- translate backend code comments to English

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6884233818608330b2d081be963f96c1